### PR TITLE
fix: enables default tests to pass

### DIFF
--- a/template.json
+++ b/template.json
@@ -16,7 +16,7 @@
     "scripts": {
       "start": "craco start",
       "build": "craco build",
-      "test": "craco test",
+      "test": "craco test -- --config=config/jest.config.js",
       "eject": "craco eject",
       "prestart": "dfx start --background; dfx deploy",
       "poststart": "dfx stop"

--- a/template/config/generateAliases.js
+++ b/template/config/generateAliases.js
@@ -1,0 +1,27 @@
+const path = require("path");
+
+const dfxJson = require(`${__dirname}/../dfx.json`);
+
+const generateAliases = () => {
+  const aliases = Object.entries(dfxJson.canisters).reduce(
+    (acc, [name, value]) => {
+      const outputRoot = path.join(
+        __dirname,
+        `../.dfx/local/${dfxJson.defaults.build.output}`,
+        name
+      );
+      const filename = path.basename(value.main, ".mo");
+      return {
+        ...acc,
+        ["ic:canisters/" + name]: path.join(outputRoot, name + ".js"),
+        ["ic:idl/" + name]: path.join(outputRoot, name + ".did.js"),
+      };
+    },
+    {}
+  );
+  return aliases;
+};
+
+module.exports = {
+  default: generateAliases,
+};

--- a/template/config/jest.config.js
+++ b/template/config/jest.config.js
@@ -1,0 +1,13 @@
+const generateAliases = require("./generateAliases").default;
+
+const aliases = generateAliases();
+const moduleMap = {};
+for (const key in aliases) {
+  if (Object.hasOwnProperty.call(aliases, key)) {
+    moduleMap[`^${key}$`] = aliases[key];
+  }
+}
+
+module.exports = {
+  moduleNameMapper: moduleMap,
+};

--- a/template/craco.config.js
+++ b/template/craco.config.js
@@ -1,29 +1,13 @@
 const webpack = require('webpack')
 const path = require('path')
+const generateAliases = require('./config/generateAliases').default
 
 module.exports = {
   plugins: [
     {
       plugin: {
         overrideWebpackConfig: ({ webpackConfig }) => {
-          const dfxJson = require(`${__dirname}/dfx.json`)
-
-          const aliases = Object.entries(dfxJson.canisters).reduce(
-            (acc, [name, value]) => {
-              const outputRoot = path.join(
-                __dirname,
-                `.dfx/local/${dfxJson.defaults.build.output}`,
-                name
-              )
-              const filename = path.basename(value.main, '.mo')
-              return {
-                ...acc,
-                ['ic:canisters/' + name]: path.join(outputRoot, name + '.js'),
-                ['ic:idl/' + name]: path.join(outputRoot, name + '.did.js'),
-              }
-            },
-            {}
-          )
+          const aliases = generateAliases()
 
           return {
             ...webpackConfig,

--- a/template/gitignore
+++ b/template/gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.dfx
 
 npm-debug.log*
 yarn-debug.log*

--- a/template/src/__mocks__/ic:canisters/test.js
+++ b/template/src/__mocks__/ic:canisters/test.js
@@ -1,0 +1,8 @@
+const stubbedInterface = {
+  getValue: () =>
+    new Promise((resolve, reject) => {
+      resolve("test value");
+    }),
+};
+
+export default stubbedInterface;


### PR DESCRIPTION
generates Jest config using shared generateAliases util
adds default mock for example canister